### PR TITLE
remove `indexof` dep

### DIFF
--- a/component.json
+++ b/component.json
@@ -4,9 +4,7 @@
   "description": "Testing component used to fake different protocols from the browser",
   "version": "0.0.1",
   "keywords": [],
-  "dependencies": {
-    "component/indexof": "0.0.1"
-  },
+  "dependencies": {},
   "development": {
     "component/assert": "*"
   },

--- a/index.js
+++ b/index.js
@@ -1,12 +1,5 @@
 
 /**
- * Required modules
- */
-
-var indexOf = require('indexof');
-
-
-/**
  * Convenience alias
  */
 


### PR DESCRIPTION
it's not used anywhere, so why require it? :p
